### PR TITLE
change lookup for query to get a list for fact __controller_api_organizations

### DIFF
--- a/roles/controller_casc_desired_state/tasks/organizations_desired_state.yml
+++ b/roles/controller_casc_desired_state/tasks/organizations_desired_state.yml
@@ -29,7 +29,7 @@
       - "{{ controller_validate_certs }}"
 
 - set_fact:
-    __controller_api_organizations: "{{ lookup('ansible.controller.controller_api', 'organizations',
+    __controller_api_organizations: "{{ query('ansible.controller.controller_api', 'organizations',
       host=controller_hostname, username=controller_username, password=controller_password, verify_ssl=controller_validate_certs) }}"
 
 - name: "DESIRED STATE: Find the difference of Organizations between what is on the Controller versus curated list."


### PR DESCRIPTION
Now, when you run the desired state from normal organization, the operations fail because redhat_cop.controller_casc.controller_object_diff_temp needs that __controller_api_organizations to be a list but, logically, from a normal org, only there is a org. If we change lookup for query, we allways get a list and then, desired state will work propertly.