### PR TITLE
fix version in galaxy.yml for CICD. Fix empty list of objects

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: redhat_cop
 name: controller_casc
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.0.156
+version: $RELEASE
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/controller_casc_from_aap/tasks/credential_types_from_aap_improved.yml
+++ b/roles/controller_casc_from_aap/tasks/credential_types_from_aap_improved.yml
@@ -1,7 +1,13 @@
 ---
-- name: "Get current Credential Types from the API"
+- name: "Get current Credential Types from the API when AAP"
   set_fact:
-    credential_types_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/credential_types/', query_params={ 'managed_by_tower': false }, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) }}"
+    credential_types_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/credential_types/', query_params={ 'managed': false }, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) }}"
+  when: is_aap
+
+- name: "Get current Credential Types from the API when Tower"
+  set_fact:
+    credential_types_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/credential_types/', query_params={ 'managed_by_tower': false }, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_al    l=true) }}"
+  when: not is_aap
 
 - name: "Create the output directory for credential types: {{ output_path }}"
   file:

--- a/roles/controller_casc_from_aap/tasks/credentials_from_aap_improved.yml
+++ b/roles/controller_casc_from_aap/tasks/credentials_from_aap_improved.yml
@@ -18,7 +18,7 @@
     path: "{{ output_path }}/{{ needed_path }}"
     state: directory
     mode: '0755'
-  loop: "{{ needed_paths }}"
+  loop: "{{ needed_paths | default([]) }}"
   loop_control:
     loop_var: needed_path
     label: "{{ output_path }}/{{ needed_path }}"
@@ -30,7 +30,7 @@
     mode: '0644'
   vars:
     current_credentials_asset_value: "{{ credentials_org_template.value }}"
-  loop: "{{ credentials_orgs | dict2items }}"
+  loop: "{{ credentials_orgs | default({}) | dict2items }}"
   loop_control:
     loop_var: credentials_org_template
     label: "{{ output_path }}/{{ credentials_org_template.value[0].summary_fields.organization.name | default('ORGANIZATIONLESS') }}/current_credentials.yaml"

--- a/roles/controller_casc_from_aap/tasks/inventory_from_aap_improved.yml
+++ b/roles/controller_casc_from_aap/tasks/inventory_from_aap_improved.yml
@@ -37,7 +37,7 @@
     path: "{{ output_path }}/{{ needed_path }}"
     state: directory
     mode: '0755'
-  loop: "{{ needed_paths }}"
+  loop: "{{ needed_paths | default([]) }}"
   loop_control:
     loop_var: needed_path
     label: "{{ output_path }}/{{ needed_path }}"
@@ -49,7 +49,7 @@
     mode: '0644'
   vars:
     current_inventories_asset_value: "{{ current_inventory_dir.value }}"
-  loop: "{{ current_inventories | dict2items }}"
+  loop: "{{ current_inventories | default({}) | dict2items }}"
   loop_control:
     loop_var: current_inventory_dir
     label: "{{ output_path }}/{{ current_inventory_dir.key }}/current_inventories.yaml"
@@ -63,7 +63,7 @@
   vars:
     output_path: "{{ local_output_path }}/{{ current_inventory_sources.key }}"
     current_organization_inventories: "{{ current_inventory_sources.value }}"
-  loop: "{{ current_inventories | dict2items }}"
+  loop: "{{ current_inventories | default({}) | dict2items }}"
   loop_control:
     loop_var: current_inventory_sources
     label: "{{ local_output_path }}/{{ current_inventory_sources.key }}"
@@ -73,7 +73,7 @@
   vars:
     output_path: "{{ local_output_path }}/{{ current_inventory_hosts.key }}"
     current_organization_inventories: "{{ current_inventory_hosts.value | json_query('[*].{hosts: hosts, name: name}') }}"
-  loop: "{{ current_inventories | dict2items }}"
+  loop: "{{ current_inventories | default({}) | dict2items }}"
   loop_control:
     loop_var: current_inventory_hosts
     label: "{{ local_output_path }}/{{ current_inventory_hosts.key }}"
@@ -83,7 +83,7 @@
   vars:
     output_path: "{{ local_output_path }}/{{ current_inventory_groups.key }}"
     current_organization_inventories: "{{ current_inventory_groups.value }}"
-  loop: "{{ current_inventories | dict2items }}"
+  loop: "{{ current_inventories | default({}) | dict2items }}"
   loop_control:
     loop_var: current_inventory_groups
     label: "{{ local_output_path }}/{{ current_inventory_groups.key }}"

--- a/roles/controller_casc_from_aap/tasks/job_templates_from_aap_improved.yml
+++ b/roles/controller_casc_from_aap/tasks/job_templates_from_aap_improved.yml
@@ -17,7 +17,7 @@
     path: "{{ output_path }}/{{ needed_path }}"
     state: directory
     mode: '0755'
-  loop: "{{ needed_paths }}"
+  loop: "{{ needed_paths | default([]) }}"
   loop_control:
     loop_var: needed_path
     label: "{{ output_path }}/{{ needed_path }}"
@@ -29,7 +29,7 @@
     mode: '0644'
   vars:
     current_job_templates_asset_value: "{{ job_templates_org_template.value }}"
-  loop: "{{ job_templates_orgs | dict2items }}"
+  loop: "{{ job_templates_orgs  | default({}) | dict2items }}"
   loop_control:
     loop_var: job_templates_org_template
     label: "{{ output_path }}/{{ job_templates_org_template.value[0].summary_fields.organization.name | default('ORGANIZATIONLESS') }}/current_job_templates.yaml"

--- a/roles/controller_casc_from_aap/tasks/notification_templates_from_aap_improved.yml
+++ b/roles/controller_casc_from_aap/tasks/notification_templates_from_aap_improved.yml
@@ -12,12 +12,12 @@
     loop_var: notification_templates_org
     label: "{{ notification_templates_org.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }} - {{ notification_templates_org.name }}"
 
-- name: "Create the output directory for notification templatess: {{ output_path }}/<ORGANIZATION_NAME>"
+- name: "Create the output directory for notification templates: {{ output_path }}/<ORGANIZATION_NAME>"
   file:
     path: "{{ output_path }}/{{ needed_path }}"
     state: directory
     mode: '0755'
-  loop: "{{ needed_paths }}"
+  loop: "{{ needed_paths | default([]) }}"
   loop_control:
     loop_var: needed_path
     label: "{{ output_path }}/{{ needed_path }}"
@@ -29,7 +29,7 @@
     mode: '0644'
   vars:
     current_notification_templates_asset_value: "{{ notification_templates_org_template.value }}"
-  loop: "{{ notification_templates_orgs | dict2items }}"
+  loop: "{{ notification_templates_orgs | default({}) | dict2items }}"
   loop_control:
     loop_var: notification_templates_org_template
     label: "{{ output_path }}/{{ notification_templates_org_template.value[0].summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}/current_notification_templates.yaml"

--- a/roles/controller_casc_from_aap/tasks/projects_from_aap_improved.yml
+++ b/roles/controller_casc_from_aap/tasks/projects_from_aap_improved.yml
@@ -17,7 +17,7 @@
     path: "{{ output_path }}/{{ needed_path }}"
     state: directory
     mode: '0755'
-  loop: "{{ needed_paths }}"
+  loop: "{{ needed_paths | default([]) }}"
   loop_control:
     loop_var: needed_path
     label: "{{ output_path }}/{{ needed_path }}"
@@ -29,7 +29,7 @@
     mode: '0644'
   vars:
     current_projects_asset_value: "{{ projects_org_template.value }}"
-  loop: "{{ projects_orgs | dict2items }}"
+  loop: "{{ projects_orgs | default({}) | dict2items }}"
   loop_control:
     loop_var: projects_org_template
     label: "{{ output_path }}/{{ projects_org_template.value[0].summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}/current_projects.yaml"

--- a/roles/controller_casc_from_aap/tasks/teams_from_aap_improved.yml
+++ b/roles/controller_casc_from_aap/tasks/teams_from_aap_improved.yml
@@ -17,7 +17,7 @@
     path: "{{ output_path }}/{{ needed_path }}"
     state: directory
     mode: '0755'
-  loop: "{{ needed_paths }}"
+  loop: "{{ needed_paths | default([]) }}"
   loop_control:
     loop_var: needed_path
     label: "{{ output_path }}/{{ needed_path }}"
@@ -29,7 +29,7 @@
     mode: '0644'
   vars:
     current_teams_asset_value: "{{ teams_org_template.value }}"
-  loop: "{{ teams_orgs | dict2items }}"
+  loop: "{{ teams_orgs  | default({}) | dict2items }}"
   loop_control:
     loop_var: teams_org_template
     label: "{{ output_path }}/{{ teams_org_template.value[0].summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}/current_teams.yaml"

--- a/roles/controller_casc_from_aap/tasks/workflow_job_template_nodes_from_aap_improved.yml
+++ b/roles/controller_casc_from_aap/tasks/workflow_job_template_nodes_from_aap_improved.yml
@@ -16,7 +16,7 @@
     path: "{{ output_path }}/{{ needed_path }}"
     state: directory
     mode: '0755'
-  loop: "{{ needed_paths }}"
+  loop: "{{ needed_paths | default([]) }}"
   loop_control:
     loop_var: needed_path
     label: "{{ output_path }}/{{ needed_path }}"
@@ -29,7 +29,7 @@
   vars:
     workflow_job_template_name: "{{ current_wfjtn_asset_value.key }}"
     # workflow_job_template_organization: "{{ query('ansible.controller.controller_api', current_wfjtn_asset_value.value.wfjtn_url, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].summary_fields.organization.name | default('ToDo: The WF node  must have an organization') }}"
-  loop: "{{ wfjtn_lookvar | dict2items }}"
+  loop: "{{ wfjtn_lookvar | default({}) | dict2items }}"
   loop_control:
     loop_var: current_wfjtn_asset_value
     label: "{{ output_path }}/{{ current_wfjtn_asset_value.value.organization }}/current_workflow_job_template_nodes_{{ workflow_job_template_name }}.yaml"

--- a/roles/controller_casc_from_aap/tasks/workflow_job_templates_from_aap_improved.yml
+++ b/roles/controller_casc_from_aap/tasks/workflow_job_templates_from_aap_improved.yml
@@ -17,7 +17,7 @@
     path: "{{ output_path }}/{{ needed_path }}"
     state: directory
     mode: '0755'
-  loop: "{{ needed_paths }}"
+  loop: "{{ needed_paths | default([]) }}"
   loop_control:
     loop_var: needed_path
     label: "{{ output_path }}/{{ needed_path }}"
@@ -29,7 +29,7 @@
     mode: '0644'
   vars:
     current_workflow_job_templates_asset_value: "{{ workflow_job_templates_org_template.value }}"
-  loop: "{{ workflow_job_templates_orgs | dict2items }}"
+  loop: "{{ workflow_job_templates_orgs | default({}) | dict2items }}"
   loop_control:
     loop_var: workflow_job_templates_org_template
     label: "{{ output_path }}/{{ workflow_job_templates_org_template.value[0].summary_fields.organization.name | default('ORGANIZATIONLESS') }}/current_workflow_job_templates.yaml"

--- a/roles/controller_casc_from_aap/templates/current_job_templates_improved.j2
+++ b/roles/controller_casc_from_aap/templates/current_job_templates_improved.j2
@@ -31,7 +31,7 @@ controller_templates:
 {% endif %}
 {%- endif -%}
 {% if is_aap %}
-    execution_environment: "{{ job_template.summary_fields.execution_environment.name }}"
+    execution_environment: "{{ job_template.summary_fields.execution_environment.name | default(omit) }}"
 {% endif %}
 {% endfor %}
 ...


### PR DESCRIPTION
A few fixes:
1 - Version variable needs to be $RELEASE in galaxy.yml for CICD works correctly.
2 - Credential_types api answer is different between aap and tower. AAP give managed parameter while tower give managed_by_tower parameter.
3- execution_environment can be empty in a job template
4- Some loops didn't work when tower/controller has not objects of some type. For example, if you don't have inventories, you will get  an empty current_inventories so you can't loop it in the next tasks and they will fail.